### PR TITLE
Add NEOM PM workspace front-end

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+node_modules
+.dist
+.DS_Store
+.vite
+.idea
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+package-lock.json
+pnpm-lock.yaml

--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
-# GIS
-GIS Repository
+# NEOM PM Workspace
+
+A lightweight React/Vite workspace designed to help NEOM project teams capture project portfolio data, stage gates, BIM deliverables, LUP registers, and QMS evidence with full traceability to SharePoint/EDMS sources. All data is stored in the browser via `localStorage` and can be exported or imported as JSON for handover.
+
+## Getting started
+
+```bash
+npm install
+npm run dev
+```
+
+The development server runs on port 5173 by default. Use `npm run build` to produce a static bundle for hosting.
+
+## Features
+
+- Portfolio register with geospatial preview (Leaflet optional install)
+- Stage gate checklist management aligned to NEOM procedures
+- BIM deliverable matrix per discipline and stage
+- Land Use Permit tracking aligned to NUP-PRC-001
+- QMS evidence tracker for PQD, Method Statements, EHS, and more
+- Custom task board with discipline assignments and due dates
+- Admin controls for disciplines and LUP review sectors
+
+Install `react-leaflet` and `leaflet` if you want to enable the interactive map tiles in the Portfolio view.

--- a/favicon.svg
+++ b/favicon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f766e" />
+      <stop offset="100%" stop-color="#bef264" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="16" fill="#020617" />
+  <path d="M16 16h32v8H24v8h16v8H24v8h24v8H16z" fill="url(#g)" />
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>NEOM PM Workspace</title>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-o9N1j7kGStp2zS1xwF8A2HxEyh3F2Sl4dX/dgKa4bVU=" crossorigin="" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "neom-pm-workspace",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview --host"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^5.2.0"
+  }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,89 @@
+import React, { useEffect, useState } from "react";
+import { Routes, Route } from "react-router-dom";
+import Sidebar from "./components/Sidebar.jsx";
+import Dashboard from "./modules/Dashboard.jsx";
+import Portfolio from "./modules/Portfolio.jsx";
+import StageGates from "./modules/StageGates.jsx";
+import LUP from "./modules/LUP.jsx";
+import BIM from "./modules/BIM.jsx";
+import QMS from "./modules/QMS.jsx";
+import Tasks from "./modules/Tasks.jsx";
+import Admin from "./modules/Admin.jsx";
+import { useStore } from "./store.js";
+
+export default function App() {
+  const store = useStore();
+  const [data, setData] = useState(store.get());
+
+  useEffect(() => store.subscribe(setData), [store]);
+
+  const patch = (fn) => store.patch(fn);
+
+  const handleExport = () => {
+    const blob = new Blob([store.export()], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = "neom_pm_workspace.json";
+    anchor.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleImport = (event) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      try {
+        store.import(reader.result);
+      } catch (error) {
+        console.error(error);
+        window.alert("Unable to import file. Please check the JSON structure.");
+      }
+    };
+    reader.readAsText(file);
+    event.target.value = "";
+  };
+
+  return (
+    <div className="app">
+      <Sidebar />
+      <main>
+        <header className="header">
+          <div className="right">
+            <span className="badge">Local autosave enabled</span>
+          </div>
+          <div className="right">
+            <label className="btn secondary">
+              Import JSON
+              <input
+                type="file"
+                accept="application/json"
+                onChange={handleImport}
+                style={{ display: "none" }}
+              />
+            </label>
+            <button className="btn" onClick={handleExport}>
+              Export
+            </button>
+          </div>
+        </header>
+        <div className="container">
+          <Routes>
+            <Route path="/" element={<Dashboard data={data} patch={patch} />} />
+            <Route path="/portfolio" element={<Portfolio data={data} patch={patch} />} />
+            <Route path="/stage-gates" element={<StageGates data={data} patch={patch} />} />
+            <Route path="/lup" element={<LUP data={data} patch={patch} />} />
+            <Route path="/bim" element={<BIM data={data} patch={patch} />} />
+            <Route path="/qms" element={<QMS data={data} patch={patch} />} />
+            <Route path="/tasks" element={<Tasks data={data} patch={patch} />} />
+            <Route path="/admin" element={<Admin data={data} patch={patch} />} />
+          </Routes>
+        </div>
+        <footer className="footer">
+          <span>© {new Date().getFullYear()} NEOM PM Workspace</span>
+        </footer>
+      </main>
+    </div>
+  );
+}

--- a/src/components/MiniMap.jsx
+++ b/src/components/MiniMap.jsx
@@ -1,0 +1,51 @@
+import React, { useEffect, useState } from "react";
+
+export default function MiniMap({ center = [27.5, 36.5], markers = [] }) {
+  const [leaflet, setLeaflet] = useState(null);
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        const mod = await import("react-leaflet");
+        if (mounted) {
+          setLeaflet(mod);
+        }
+      } catch (error) {
+        console.warn("Leaflet not installed", error);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  if (!leaflet) {
+    return (
+      <div className="card" style={{ height: 300 }}>
+        <div className="small">Map unavailable (install react-leaflet + leaflet to enable)</div>
+        <code className="mono">npm i react-leaflet leaflet</code>
+      </div>
+    );
+  }
+
+  const { MapContainer, TileLayer, Marker, Popup } = leaflet;
+
+  return (
+    <div className="card" style={{ padding: 0, overflow: "hidden" }}>
+      <MapContainer center={center} zoom={8} style={{ height: 300 }}>
+        <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
+        {markers.map((marker) => (
+          <Marker key={marker.id} position={[marker.lat, marker.lon]}>
+            <Popup>
+              <div>
+                <strong>{marker.name}</strong>
+                <div className="small">{marker.stage}</div>
+              </div>
+            </Popup>
+          </Marker>
+        ))}
+      </MapContainer>
+    </div>
+  );
+}

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { NavLink } from "react-router-dom";
+
+function NavButton({ to, children }) {
+  return (
+    <NavLink to={to} className={({ isActive }) => (isActive ? "active" : "") }>
+      {({ isActive }) => (
+        <button className={isActive ? "active" : ""}>{children}</button>
+      )}
+    </NavLink>
+  );
+}
+
+export default function Sidebar() {
+  return (
+    <aside className="sidebar">
+      <div className="brand">
+        <div className="logo" />
+        <h1>NEOM PM</h1>
+      </div>
+      <nav className="nav">
+        <NavButton to="/">Dashboard</NavButton>
+        <NavButton to="/portfolio">Portfolio</NavButton>
+        <NavButton to="/stage-gates">Stage Gates</NavButton>
+        <NavButton to="/lup">Land Use Permits</NavButton>
+        <NavButton to="/bim">BIM</NavButton>
+        <NavButton to="/qms">QMS</NavButton>
+        <NavButton to="/tasks">Tasks</NavButton>
+        <NavButton to="/admin">Admin</NavButton>
+      </nav>
+      <div className="small">Traceability-first PM toolkit</div>
+    </aside>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,13 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
+import App from "./App.jsx";
+import "./styles.css";
+
+ReactDOM.createRoot(document.getElementById("root")).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/src/modules/Admin.jsx
+++ b/src/modules/Admin.jsx
@@ -1,0 +1,88 @@
+import React, { useState } from "react";
+
+export default function Admin({ data, patch }) {
+  const { settings } = data;
+  const [disciplineInput, setDisciplineInput] = useState("");
+  const [sectorInput, setSectorInput] = useState("");
+
+  const addDiscipline = () => {
+    if (!disciplineInput.trim()) return;
+    patch((draft) => {
+      draft.settings.disciplines.push(disciplineInput.trim());
+    });
+    setDisciplineInput("");
+  };
+
+  const removeDiscipline = (index) => {
+    patch((draft) => {
+      draft.settings.disciplines.splice(index, 1);
+    });
+  };
+
+  const addSector = () => {
+    if (!sectorInput.trim()) return;
+    patch((draft) => {
+      draft.settings.lupSectors.push(sectorInput.trim());
+    });
+    setSectorInput("");
+  };
+
+  const removeSector = (index) => {
+    patch((draft) => {
+      draft.settings.lupSectors.splice(index, 1);
+    });
+  };
+
+  return (
+    <div className="grid2">
+      <div className="card">
+        <h2>Disciplines</h2>
+        <div style={{ display: "flex", gap: 10, marginBottom: 12 }}>
+          <input
+            className="input"
+            placeholder="Add discipline"
+            value={disciplineInput}
+            onChange={(event) => setDisciplineInput(event.target.value)}
+          />
+          <button className="btn" onClick={addDiscipline}>
+            Add
+          </button>
+        </div>
+        <ul style={{ listStyle: "none", padding: 0, margin: 0, display: "grid", gap: 8 }}>
+          {settings.disciplines.map((discipline, index) => (
+            <li key={discipline} className="card" style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+              <span>{discipline}</span>
+              <button className="btn secondary" onClick={() => removeDiscipline(index)}>
+                Remove
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div className="card">
+        <h2>LUP Review Sectors</h2>
+        <div style={{ display: "flex", gap: 10, marginBottom: 12 }}>
+          <input
+            className="input"
+            placeholder="Add sector"
+            value={sectorInput}
+            onChange={(event) => setSectorInput(event.target.value)}
+          />
+          <button className="btn" onClick={addSector}>
+            Add
+          </button>
+        </div>
+        <ul style={{ listStyle: "none", padding: 0, margin: 0, display: "grid", gap: 8 }}>
+          {settings.lupSectors.map((sector, index) => (
+            <li key={sector} className="card" style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+              <span>{sector}</span>
+              <button className="btn secondary" onClick={() => removeSector(index)}>
+                Remove
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/src/modules/BIM.jsx
+++ b/src/modules/BIM.jsx
@@ -1,0 +1,104 @@
+import React from "react";
+
+const DELIVERABLE_TYPES = [
+  "CAD",
+  "BIM",
+  "IFC",
+  "Navisworks",
+  "Clash",
+  "Compliance",
+  "Comments"
+];
+
+const STATUSES = ["Not Started", "In Progress", "Submitted", "Approved", "N/A"];
+
+export default function BIM({ data, patch }) {
+  const { portfolio, settings, bim } = data;
+
+  const ensure = (draft, projectId, discipline, type) => {
+    draft.bim[projectId] = draft.bim[projectId] ?? {};
+    draft.bim[projectId][discipline] = draft.bim[projectId][discipline] ?? {};
+    draft.bim[projectId][discipline][type] =
+      draft.bim[projectId][discipline][type] ?? {
+        status: "Not Started",
+        link: "",
+        comments: ""
+      };
+  };
+
+  const update = (projectId, discipline, type, field, value) => {
+    patch((draft) => {
+      ensure(draft, projectId, discipline, type);
+      draft.bim[projectId][discipline][type][field] = value;
+    });
+  };
+
+  return (
+    <div>
+      <h2>BIM Deliverables (PRC-005 reference)</h2>
+      {portfolio.length === 0 && <div className="card small">Add a project to begin.</div>}
+      {portfolio.map((project) => (
+        <section key={project.id} className="card" style={{ marginTop: 18 }}>
+          <strong>{project.name}</strong>
+          {settings.disciplines.map((discipline) => (
+            <div key={discipline} className="card" style={{ marginTop: 14 }}>
+              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                <h3 style={{ margin: 0 }}>{discipline}</h3>
+              </div>
+              <table className="table">
+                <thead>
+                  <tr>
+                    <th>Deliverable</th>
+                    <th>Status</th>
+                    <th>SharePoint / EDMS link</th>
+                    <th>Comments</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {DELIVERABLE_TYPES.map((type) => {
+                    const cell = bim[project.id]?.[discipline]?.[type] ?? {
+                      status: "Not Started",
+                      link: "",
+                      comments: ""
+                    };
+                    return (
+                      <tr key={type}>
+                        <td>{type}</td>
+                        <td>
+                          <select
+                            className="select"
+                            value={cell.status}
+                            onChange={(event) => update(project.id, discipline, type, "status", event.target.value)}
+                          >
+                            {STATUSES.map((status) => (
+                              <option key={status}>{status}</option>
+                            ))}
+                          </select>
+                        </td>
+                        <td>
+                          <input
+                            className="input"
+                            placeholder="https://..."
+                            value={cell.link}
+                            onChange={(event) => update(project.id, discipline, type, "link", event.target.value)}
+                          />
+                        </td>
+                        <td>
+                          <input
+                            className="input"
+                            value={cell.comments}
+                            onChange={(event) => update(project.id, discipline, type, "comments", event.target.value)}
+                          />
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          ))}
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/src/modules/Dashboard.jsx
+++ b/src/modules/Dashboard.jsx
@@ -1,0 +1,123 @@
+import React, { useMemo } from "react";
+
+function KpiCard({ label, value, suffix = "%" }) {
+  const percent = Math.max(0, Math.min(100, value ?? 0));
+  return (
+    <div className="card">
+      <div style={{ display: "flex", justifyContent: "space-between" }}>
+        <span>{label}</span>
+        <span className="small">
+          {percent}
+          {suffix}
+        </span>
+      </div>
+      <div className="kpi" style={{ marginTop: 12 }}>
+        <span style={{ width: `${percent}%` }} />
+      </div>
+    </div>
+  );
+}
+
+function StageDistribution({ projects }) {
+  const counts = useMemo(() => {
+    const tally = new Map();
+    projects.forEach((project) => {
+      tally.set(project.stage, (tally.get(project.stage) ?? 0) + 1);
+    });
+    return Array.from(tally.entries()).sort();
+  }, [projects]);
+
+  return (
+    <div className="card">
+      <h3>Stage Distribution</h3>
+      {counts.length === 0 ? (
+        <div className="small">No projects registered.</div>
+      ) : (
+        <div>
+          {counts.map(([stage, count]) => (
+            <div key={stage} style={{ marginTop: 12 }}>
+              <div style={{ display: "flex", justifyContent: "space-between" }}>
+                <strong>{stage}</strong>
+                <span className="small">{count} project(s)</span>
+              </div>
+              <div className="kpi" style={{ marginTop: 6 }}>
+                <span style={{ width: `${Math.min(100, count * 20)}%` }} />
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function RiskSpark({ risks }) {
+  const max = Math.max(...risks.map((r) => r.exposure), 0) || 1;
+  return (
+    <svg viewBox="0 0 400 120" style={{ width: "100%", height: 120 }}>
+      <defs>
+        <linearGradient id="riskGradient" x1="0" x2="1" y1="0" y2="0">
+          <stop offset="0%" stopColor="#22d3ee" />
+          <stop offset="100%" stopColor="#f87171" />
+        </linearGradient>
+      </defs>
+      <polyline
+        fill="none"
+        stroke="url(#riskGradient)"
+        strokeWidth="4"
+        points={risks
+          .map((risk, index) => {
+            const x = (index / Math.max(risks.length - 1, 1)) * 360 + 20;
+            const y = 100 - (risk.exposure / max) * 80;
+            return `${x},${y}`;
+          })
+          .join(" ")}
+      />
+      {risks.map((risk, index) => {
+        const x = (index / Math.max(risks.length - 1, 1)) * 360 + 20;
+        const y = 100 - (risk.exposure / max) * 80;
+        return (
+          <g key={risk.id}>
+            <circle cx={x} cy={y} r={6} fill="#22d3ee" />
+            <text x={x} y={110} fill="#94a3b8" fontSize="10" textAnchor="middle">
+              {risk.projectId}
+            </text>
+          </g>
+        );
+      })}
+    </svg>
+  );
+}
+
+export default function Dashboard({ data }) {
+  const { portfolio, tasks, risks } = data;
+  const portfolioCount = portfolio.length;
+  const averageProgress =
+    portfolioCount === 0
+      ? 0
+      : Math.round(portfolio.reduce((sum, item) => sum + (item.progress ?? 0), 0) / portfolioCount);
+  const mobilization = Math.round(
+    portfolio.reduce((sum, item) => sum + (item.progress ?? 0), 0) / Math.max(portfolioCount, 1)
+  );
+  const checklistCompletion = tasks.length === 0 ? 0 : Math.round((tasks.filter((t) => t.status === "Done").length / tasks.length) * 100);
+
+  return (
+    <div className="grid3">
+      <KpiCard label={`Active Projects (${portfolioCount})`} value={100} />
+      <KpiCard label="Average Progress" value={averageProgress} />
+      <KpiCard label="Mobilization" value={mobilization} />
+      <KpiCard label="Task Closure" value={checklistCompletion} />
+
+      <StageDistribution projects={portfolio} />
+
+      <div className="card">
+        <h3>Risk Exposure</h3>
+        {risks.length === 0 ? (
+          <div className="small">No risks logged yet.</div>
+        ) : (
+          <RiskSpark risks={risks} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/modules/LUP.jsx
+++ b/src/modules/LUP.jsx
@@ -1,0 +1,182 @@
+import React from "react";
+
+const STATUSES = [
+  "Draft",
+  "Submitted",
+  "In Progress",
+  "Endorsed",
+  "Code A",
+  "Code B",
+  "Code C",
+  "Withdrawn",
+  "Not Yet Applied",
+  "N/A"
+];
+
+const STEPS = ["Prescreening Review", "Application Review", "LUC", "BoD"];
+
+export default function LUP({ data, patch }) {
+  const { portfolio, lup } = data;
+
+  const ensure = (draft, projectId) => {
+    draft.lup[projectId] =
+      draft.lup[projectId] ?? [
+        {
+          id: `LUP-${projectId}-001`,
+          title: "New Permit",
+          area: "",
+          validFrom: "",
+          validTo: "",
+          status: "Draft",
+          step: "Prescreening Review",
+          evidence: "",
+          notes: ""
+        }
+      ];
+  };
+
+  const addPermit = (projectId) => {
+    patch((draft) => {
+      ensure(draft, projectId);
+      const nextIndex = draft.lup[projectId].length + 1;
+      draft.lup[projectId].push({
+        id: `LUP-${projectId}-${String(nextIndex).padStart(3, "0")}`,
+        title: "New Permit",
+        area: "",
+        validFrom: "",
+        validTo: "",
+        status: "Draft",
+        step: "Prescreening Review",
+        evidence: "",
+        notes: ""
+      });
+    });
+  };
+
+  const update = (projectId, index, field, value) => {
+    patch((draft) => {
+      ensure(draft, projectId);
+      draft.lup[projectId][index][field] = value;
+    });
+  };
+
+  const remove = (projectId, index) => {
+    if (!window.confirm("Delete LUP record?")) return;
+    patch((draft) => {
+      ensure(draft, projectId);
+      draft.lup[projectId].splice(index, 1);
+    });
+  };
+
+  return (
+    <div>
+      <h2>Land Use Permits (aligned to NUP-PRC-001)</h2>
+      {portfolio.length === 0 && <div className="card small">Add a project to manage permits.</div>}
+      {portfolio.map((project) => (
+        <div key={project.id} className="card" style={{ marginTop: 18 }}>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+            <strong>{project.name}</strong>
+            <button className="btn secondary" onClick={() => addPermit(project.id)}>
+              Add permit
+            </button>
+          </div>
+          <table className="table">
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>Title</th>
+                <th>Area</th>
+                <th>Valid From</th>
+                <th>Valid To</th>
+                <th>Status</th>
+                <th>Process Step</th>
+                <th>Evidence / Links</th>
+                <th>Notes</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {(lup[project.id] ?? []).map((row, index) => (
+                <tr key={row.id}>
+                  <td className="mono">{row.id}</td>
+                  <td>
+                    <input
+                      className="input"
+                      value={row.title}
+                      onChange={(event) => update(project.id, index, "title", event.target.value)}
+                    />
+                  </td>
+                  <td>
+                    <input
+                      className="input"
+                      value={row.area}
+                      onChange={(event) => update(project.id, index, "area", event.target.value)}
+                    />
+                  </td>
+                  <td>
+                    <input
+                      className="input"
+                      type="date"
+                      value={row.validFrom}
+                      onChange={(event) => update(project.id, index, "validFrom", event.target.value)}
+                    />
+                  </td>
+                  <td>
+                    <input
+                      className="input"
+                      type="date"
+                      value={row.validTo}
+                      onChange={(event) => update(project.id, index, "validTo", event.target.value)}
+                    />
+                  </td>
+                  <td>
+                    <select
+                      className="select"
+                      value={row.status}
+                      onChange={(event) => update(project.id, index, "status", event.target.value)}
+                    >
+                      {STATUSES.map((status) => (
+                        <option key={status}>{status}</option>
+                      ))}
+                    </select>
+                  </td>
+                  <td>
+                    <select
+                      className="select"
+                      value={row.step}
+                      onChange={(event) => update(project.id, index, "step", event.target.value)}
+                    >
+                      {STEPS.map((step) => (
+                        <option key={step}>{step}</option>
+                      ))}
+                    </select>
+                  </td>
+                  <td>
+                    <input
+                      className="input"
+                      placeholder="SharePoint / EDMS link"
+                      value={row.evidence}
+                      onChange={(event) => update(project.id, index, "evidence", event.target.value)}
+                    />
+                  </td>
+                  <td>
+                    <input
+                      className="input"
+                      value={row.notes}
+                      onChange={(event) => update(project.id, index, "notes", event.target.value)}
+                    />
+                  </td>
+                  <td>
+                    <button className="btn secondary" onClick={() => remove(project.id, index)}>
+                      Delete
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/modules/Portfolio.jsx
+++ b/src/modules/Portfolio.jsx
@@ -1,0 +1,170 @@
+import React, { useState } from "react";
+import MiniMap from "../components/MiniMap.jsx";
+
+const STAGES = ["Stage 1", "Stage 2", "Stage 3", "Stage 4A", "Stage 4B"];
+
+export default function Portfolio({ data, patch }) {
+  const { portfolio } = data;
+  const [selected, setSelected] = useState(portfolio[0]?.id ?? null);
+
+  const addProject = () => {
+    patch((draft) => {
+      const nextId = `P-${String(draft.portfolio.length + 1).padStart(3, "0")}`;
+      draft.portfolio.push({
+        id: nextId,
+        name: "New Project",
+        stage: "Stage 1",
+        manager: "",
+        status: "Mobilization",
+        progress: 0,
+        lat: 27.5,
+        lon: 36.5
+      });
+      setSelected(nextId);
+    });
+  };
+
+  const removeProject = (id) => {
+    if (!window.confirm("Delete project and related registers?")) return;
+    patch((draft) => {
+      draft.portfolio = draft.portfolio.filter((project) => project.id !== id);
+      delete draft.stages[id];
+      delete draft.lup[id];
+      delete draft.bim[id];
+      delete draft.qms[id];
+      draft.tasks = draft.tasks.filter((task) => task.projectId !== id);
+      draft.risks = draft.risks.filter((risk) => risk.projectId !== id);
+    });
+    setSelected((prev) => (prev === id ? null : prev));
+  };
+
+  const update = (index, field, value) => {
+    patch((draft) => {
+      draft.portfolio[index][field] = value;
+    });
+  };
+
+  const selectedProject = portfolio.find((project) => project.id === selected) ?? portfolio[0];
+
+  return (
+    <div className="grid2">
+      <div className="card" style={{ overflowX: "auto" }}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+          <h2>Portfolio</h2>
+          <button className="btn" onClick={addProject}>
+            Add project
+          </button>
+        </div>
+        <table className="table">
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th>Name</th>
+              <th>Stage</th>
+              <th>Manager</th>
+              <th>Status</th>
+              <th>Progress</th>
+              <th>Lat</th>
+              <th>Lon</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {portfolio.map((project, index) => (
+              <tr
+                key={project.id}
+                onClick={() => setSelected(project.id)}
+                style={{ background: selected === project.id ? "rgba(34, 211, 238, 0.08)" : undefined }}
+              >
+                <td className="mono">{project.id}</td>
+                <td>
+                  <input
+                    className="input"
+                    value={project.name}
+                    onChange={(event) => update(index, "name", event.target.value)}
+                  />
+                </td>
+                <td>
+                  <select
+                    className="select"
+                    value={project.stage}
+                    onChange={(event) => update(index, "stage", event.target.value)}
+                  >
+                    {STAGES.map((stage) => (
+                      <option key={stage}>{stage}</option>
+                    ))}
+                  </select>
+                </td>
+                <td>
+                  <input
+                    className="input"
+                    value={project.manager ?? ""}
+                    onChange={(event) => update(index, "manager", event.target.value)}
+                  />
+                </td>
+                <td>
+                  <input
+                    className="input"
+                    value={project.status ?? ""}
+                    onChange={(event) => update(index, "status", event.target.value)}
+                  />
+                </td>
+                <td style={{ width: 110 }}>
+                  <input
+                    className="input"
+                    type="number"
+                    min="0"
+                    max="100"
+                    value={project.progress ?? 0}
+                    onChange={(event) => update(index, "progress", Number(event.target.value))}
+                  />
+                </td>
+                <td style={{ width: 110 }}>
+                  <input
+                    className="input"
+                    type="number"
+                    value={project.lat}
+                    onChange={(event) => update(index, "lat", Number(event.target.value))}
+                  />
+                </td>
+                <td style={{ width: 110 }}>
+                  <input
+                    className="input"
+                    type="number"
+                    value={project.lon}
+                    onChange={(event) => update(index, "lon", Number(event.target.value))}
+                  />
+                </td>
+                <td>
+                  <button className="btn secondary" onClick={() => removeProject(project.id)}>
+                    Delete
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
+        <MiniMap
+          center={selectedProject ? [selectedProject.lat, selectedProject.lon] : [27.5, 36.5]}
+          markers={portfolio}
+        />
+        <div className="card">
+          <h3>Selected Project</h3>
+          {selectedProject ? (
+            <div className="small" style={{ display: "grid", gap: 6 }}>
+              <strong>{selectedProject.name}</strong>
+              <span>Stage: {selectedProject.stage}</span>
+              <span>Manager: {selectedProject.manager || "—"}</span>
+              <span>Progress: {selectedProject.progress ?? 0}%</span>
+              <span>Status: {selectedProject.status || "—"}</span>
+            </div>
+          ) : (
+            <div className="small">Select a project to see details.</div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/modules/QMS.jsx
+++ b/src/modules/QMS.jsx
@@ -1,0 +1,97 @@
+import React from "react";
+
+const FIELDS = [
+  { key: "mobilization", label: "Mobilization" },
+  { key: "pqd", label: "Project Quality Dossier" },
+  { key: "methodStatements", label: "Method Statements" },
+  { key: "ehs", label: "EHS" },
+  { key: "orgChart", label: "Organization Chart" },
+  { key: "etsd", label: "ETSD" },
+  { key: "pts", label: "PTS" }
+];
+
+const STATUS = ["Not Started", "In Progress", "Submitted", "Approved", "N/A"];
+
+export default function QMS({ data, patch }) {
+  const { portfolio, qms } = data;
+
+  const ensure = (draft, projectId, key) => {
+    draft.qms[projectId] = draft.qms[projectId] ?? {};
+    draft.qms[projectId][key] =
+      draft.qms[projectId][key] ?? {
+        status: "Not Started",
+        date: "",
+        link: ""
+      };
+  };
+
+  const update = (projectId, key, field, value) => {
+    patch((draft) => {
+      ensure(draft, projectId, key);
+      draft.qms[projectId][key][field] = value;
+    });
+  };
+
+  return (
+    <div>
+      <h2>Quality Records (PRC-029 / PRC-005)</h2>
+      {portfolio.length === 0 && <div className="card small">Add a project to begin.</div>}
+      {portfolio.map((project) => (
+        <div key={project.id} className="card" style={{ marginTop: 18 }}>
+          <strong>{project.name}</strong>
+          <table className="table">
+            <thead>
+              <tr>
+                <th>Item</th>
+                <th>Status</th>
+                <th>Date</th>
+                <th>SharePoint / EDMS Link</th>
+              </tr>
+            </thead>
+            <tbody>
+              {FIELDS.map((field) => {
+                const row = qms[project.id]?.[field.key] ?? {
+                  status: "Not Started",
+                  date: "",
+                  link: ""
+                };
+                return (
+                  <tr key={field.key}>
+                    <td>{field.label}</td>
+                    <td>
+                      <select
+                        className="select"
+                        value={row.status}
+                        onChange={(event) => update(project.id, field.key, "status", event.target.value)}
+                      >
+                        {STATUS.map((status) => (
+                          <option key={status}>{status}</option>
+                        ))}
+                      </select>
+                    </td>
+                    <td>
+                      <input
+                        className="input"
+                        type="date"
+                        value={row.date}
+                        onChange={(event) => update(project.id, field.key, "date", event.target.value)}
+                      />
+                    </td>
+                    <td>
+                      <input
+                        className="input"
+                        placeholder="SharePoint link"
+                        value={row.link}
+                        onChange={(event) => update(project.id, field.key, "link", event.target.value)}
+                      />
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/modules/StageGates.jsx
+++ b/src/modules/StageGates.jsx
@@ -1,0 +1,129 @@
+import React from "react";
+
+const STAGES = ["Stage 1", "Stage 2", "Stage 3", "Stage 4A", "Stage 4B"];
+const DEFAULT_ITEMS = [
+  "Scope defined",
+  "Compliance checked",
+  "QA review complete",
+  "SEM comments logged",
+  "Approvals received"
+];
+
+export default function StageGates({ data, patch }) {
+  const { portfolio, stages } = data;
+
+  const ensureStage = (draft, projectId, stage) => {
+    draft.stages[projectId] = draft.stages[projectId] ?? {};
+    draft.stages[projectId][stage] =
+      draft.stages[projectId][stage] ??
+      DEFAULT_ITEMS.map((name) => ({
+        name,
+        status: "Pending",
+        owner: "",
+        remarks: ""
+      }));
+  };
+
+  const update = (projectId, stage, index, field, value) => {
+    patch((draft) => {
+      ensureStage(draft, projectId, stage);
+      draft.stages[projectId][stage][index][field] = value;
+    });
+  };
+
+  const addChecklistItem = (projectId, stage) => {
+    const name = window.prompt("Checklist item name");
+    if (!name) return;
+    patch((draft) => {
+      ensureStage(draft, projectId, stage);
+      draft.stages[projectId][stage].push({
+        name,
+        status: "Pending",
+        owner: "",
+        remarks: ""
+      });
+    });
+  };
+
+  return (
+    <div className="card" style={{ overflowX: "auto" }}>
+      <h2>Stage Gate Reviews</h2>
+      {portfolio.length === 0 && <div className="small">Add a project to begin.</div>}
+      {portfolio.map((project) => (
+        <section key={project.id} style={{ marginTop: 24 }}>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+            <div>
+              <strong>{project.name}</strong>
+              <span className="badge" style={{ marginLeft: 12 }}>
+                {project.stage}
+              </span>
+            </div>
+          </div>
+          {STAGES.map((stage) => {
+            const rows = stages[project.id]?.[stage];
+            return (
+              <div key={stage} className="card" style={{ marginTop: 14 }}>
+                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                  <h3 style={{ margin: 0 }}>{stage}</h3>
+                  <button className="btn secondary" onClick={() => addChecklistItem(project.id, stage)}>
+                    Add item
+                  </button>
+                </div>
+                <table className="table">
+                  <thead>
+                    <tr>
+                      <th>Item</th>
+                      <th>Status</th>
+                      <th>Owner</th>
+                      <th>Remarks</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {(rows ?? DEFAULT_ITEMS.map((name) => ({ name, status: "Pending", owner: "", remarks: "" }))).map(
+                      (row, index) => (
+                        <tr key={index}>
+                          <td>{row.name}</td>
+                          <td>
+                            <select
+                              className="select"
+                              value={row.status}
+                              onChange={(event) => update(project.id, stage, index, "status", event.target.value)}
+                            >
+                              {[
+                                "Pending",
+                                "In Review",
+                                "Approved",
+                                "Rejected",
+                                "N/A"
+                              ].map((status) => (
+                                <option key={status}>{status}</option>
+                              ))}
+                            </select>
+                          </td>
+                          <td>
+                            <input
+                              className="input"
+                              value={row.owner ?? ""}
+                              onChange={(event) => update(project.id, stage, index, "owner", event.target.value)}
+                            />
+                          </td>
+                          <td>
+                            <input
+                              className="input"
+                              value={row.remarks ?? ""}
+                              onChange={(event) => update(project.id, stage, index, "remarks", event.target.value)}
+                            />
+                          </td>
+                        </tr>
+                      )
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            );
+          })}
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/src/modules/Tasks.jsx
+++ b/src/modules/Tasks.jsx
@@ -1,0 +1,120 @@
+import React from "react";
+
+const STATUS = ["Open", "In Progress", "Blocked", "Done", "N/A"];
+
+export default function Tasks({ data, patch }) {
+  const { tasks, portfolio, settings } = data;
+
+  const addTask = () => {
+    patch((draft) => {
+      const nextId = `T-${String(draft.tasks.length + 1).padStart(3, "0")}`;
+      draft.tasks.push({
+        id: nextId,
+        projectId: portfolio[0]?.id ?? "",
+        title: "New Task",
+        discipline: settings.disciplines[0] ?? "",
+        due: "",
+        status: "Open"
+      });
+    });
+  };
+
+  const update = (index, field, value) => {
+    patch((draft) => {
+      draft.tasks[index][field] = value;
+    });
+  };
+
+  const remove = (index) => {
+    patch((draft) => {
+      draft.tasks.splice(index, 1);
+    });
+  };
+
+  return (
+    <div className="card" style={{ overflowX: "auto" }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <h2>Custom Tasks</h2>
+        <button className="btn" onClick={addTask}>
+          Add task
+        </button>
+      </div>
+      <table className="table">
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Project</th>
+            <th>Title</th>
+            <th>Discipline</th>
+            <th>Due</th>
+            <th>Status</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {tasks.map((task, index) => (
+            <tr key={task.id}>
+              <td className="mono">{task.id}</td>
+              <td>
+                <select
+                  className="select"
+                  value={task.projectId}
+                  onChange={(event) => update(index, "projectId", event.target.value)}
+                >
+                  <option value="">—</option>
+                  {portfolio.map((project) => (
+                    <option key={project.id} value={project.id}>
+                      {project.name}
+                    </option>
+                  ))}
+                </select>
+              </td>
+              <td>
+                <input
+                  className="input"
+                  value={task.title}
+                  onChange={(event) => update(index, "title", event.target.value)}
+                />
+              </td>
+              <td>
+                <select
+                  className="select"
+                  value={task.discipline}
+                  onChange={(event) => update(index, "discipline", event.target.value)}
+                >
+                  {settings.disciplines.map((discipline) => (
+                    <option key={discipline}>{discipline}</option>
+                  ))}
+                </select>
+              </td>
+              <td>
+                <input
+                  className="input"
+                  type="date"
+                  value={task.due}
+                  onChange={(event) => update(index, "due", event.target.value)}
+                />
+              </td>
+              <td>
+                <select
+                  className="select"
+                  value={task.status}
+                  onChange={(event) => update(index, "status", event.target.value)}
+                >
+                  {STATUS.map((status) => (
+                    <option key={status}>{status}</option>
+                  ))}
+                </select>
+              </td>
+              <td>
+                <button className="btn secondary" onClick={() => remove(index)}>
+                  Delete
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/store.js
+++ b/src/store.js
@@ -1,0 +1,164 @@
+const STORAGE_KEY = "neom_pm_workspace_v1";
+
+const defaultState = {
+  settings: {
+    disciplines: [
+      "Architecture",
+      "Structure",
+      "MEP",
+      "Infrastructure",
+      "Landscape",
+      "QS",
+      "HSE"
+    ],
+    lupSectors: [
+      "Urban Planning",
+      "Environment",
+      "Energy",
+      "Water",
+      "ETSD",
+      "Projects",
+      "Operations",
+      "OXAGON",
+      "Government Affairs",
+      "Land Mobility",
+      "Heritage",
+      "Air Mobility",
+      "Nature Region",
+      "Tanmiah (External)",
+      "NEOM Authority DPMA",
+      "Tourism",
+      "THE LINE",
+      "Tech & Digital"
+    ]
+  },
+  portfolio: [
+    {
+      id: "P-001",
+      name: "Logistics Hub",
+      lat: 27.5,
+      lon: 36.5,
+      stage: "Stage 2",
+      manager: "Shakil",
+      status: "Design",
+      progress: 42
+    },
+    {
+      id: "P-002",
+      name: "Resort Cluster",
+      lat: 27.63,
+      lon: 36.64,
+      stage: "Stage 3",
+      manager: "Aisha",
+      status: "Construction",
+      progress: 71
+    }
+  ],
+  stages: {},
+  lup: {},
+  bim: {},
+  qms: {},
+  tasks: [
+    {
+      id: "T-001",
+      projectId: "P-001",
+      title: "Issue PRC-029 stage pack",
+      discipline: "Architecture",
+      due: "2024-05-15",
+      status: "In Progress"
+    },
+    {
+      id: "T-002",
+      projectId: "P-002",
+      title: "Upload PRC-009 FRM02 review",
+      discipline: "MEP",
+      due: "2024-05-18",
+      status: "Open"
+    }
+  ],
+  risks: [
+    {
+      id: "R-001",
+      projectId: "P-002",
+      title: "Utility corridor approvals",
+      exposure: 60
+    },
+    {
+      id: "R-002",
+      projectId: "P-001",
+      title: "Supply chain delay",
+      exposure: 45
+    }
+  ]
+};
+
+let state = load();
+const subscribers = new Set();
+
+function load() {
+  if (typeof window === "undefined") {
+    return structuredClone(defaultState);
+  }
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (!stored) {
+      return structuredClone(defaultState);
+    }
+    const parsed = JSON.parse(stored);
+    return {
+      ...structuredClone(defaultState),
+      ...parsed,
+      settings: {
+        ...structuredClone(defaultState.settings),
+        ...(parsed.settings ?? {})
+      }
+    };
+  } catch (error) {
+    console.warn("Failed to load state, using defaults", error);
+    return structuredClone(defaultState);
+  }
+}
+
+function persist() {
+  if (typeof window === "undefined") {
+    return;
+  }
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+}
+
+function notify() {
+  subscribers.forEach((fn) => fn(state));
+}
+
+export function useStore() {
+  return {
+    get: () => state,
+    set: (next) => {
+      state = next;
+      persist();
+      notify();
+    },
+    patch: (fn) => {
+      const draft = structuredClone(state);
+      fn(draft);
+      state = draft;
+      persist();
+      notify();
+    },
+    subscribe: (fn) => {
+      subscribers.add(fn);
+      return () => subscribers.delete(fn);
+    },
+    reset: () => {
+      state = structuredClone(defaultState);
+      persist();
+      notify();
+    },
+    export: () => JSON.stringify(state, null, 2),
+    import: (json) => {
+      state = JSON.parse(json);
+      persist();
+      notify();
+    }
+  };
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,235 @@
+:root {
+  --bg: #05070d;
+  --panel: #0f1117;
+  --panel2: #161922;
+  --border: #1f2430;
+  --text: #f8fafc;
+  --muted: #94a3b8;
+  --accent: #22d3ee;
+  --accent-dark: #0e7490;
+  --warn: #f59e0b;
+  --danger: #f87171;
+}
+*
+{
+  box-sizing: border-box;
+}
+html,
+body,
+#root {
+  height: 100%;
+}
+body {
+  margin: 0;
+  background: radial-gradient(circle at top right, rgba(14, 165, 233, 0.15), transparent 40%), var(--bg);
+  color: var(--text);
+  font: 14px/1.5 "Inter", "Segoe UI", Roboto, system-ui, sans-serif;
+}
+a {
+  color: #67e8f9;
+  text-decoration: none;
+}
+a:hover {
+  text-decoration: underline;
+}
+.app {
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  min-height: 100vh;
+}
+.sidebar {
+  background: var(--panel);
+  border-right: 1px solid var(--border);
+  padding: 18px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.logo {
+  width: 32px;
+  height: 32px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, #bef264, #22d3ee);
+}
+.brand h1 {
+  font-size: 14px;
+  margin: 0;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.nav {
+  display: grid;
+  gap: 10px;
+}
+.nav button {
+  width: 100%;
+  text-align: left;
+  background: var(--panel2);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 12px 14px;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+.nav button:hover {
+  border-color: var(--accent);
+}
+.nav button.active {
+  background: rgba(34, 211, 238, 0.15);
+  border-color: var(--accent);
+  color: #bff3ff;
+}
+.header {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  background: rgba(5, 7, 13, 0.75);
+  border-bottom: 1px solid var(--border);
+  padding: 12px 20px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
+  backdrop-filter: blur(12px);
+}
+.container {
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+.card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 16px;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.25);
+}
+.grid2 {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+.grid3 {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+.table th,
+.table td {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+  vertical-align: middle;
+}
+.table th {
+  text-transform: uppercase;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+.table input,
+.table select,
+.input,
+.select,
+.textarea {
+  width: 100%;
+  background: var(--panel2);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 8px 10px;
+}
+.textarea {
+  min-height: 90px;
+  resize: vertical;
+}
+.btn {
+  background: var(--accent);
+  color: #022c22;
+  border: 0;
+  padding: 10px 14px;
+  border-radius: 12px;
+  cursor: pointer;
+  font-weight: 600;
+  transition: filter 0.15s ease;
+}
+.btn:hover {
+  filter: brightness(1.05);
+}
+.btn.secondary {
+  background: var(--panel2);
+  color: var(--text);
+  border: 1px solid var(--border);
+}
+.btn.secondary:hover {
+  border-color: var(--accent-dark);
+}
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: rgba(148, 163, 184, 0.1);
+  color: var(--muted);
+}
+.small {
+  font-size: 12px;
+  color: var(--muted);
+}
+.mono {
+  font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+}
+.kpi {
+  width: 100%;
+  height: 10px;
+  background: #1f2937;
+  border-radius: 999px;
+  overflow: hidden;
+}
+.kpi span {
+  display: block;
+  height: 100%;
+  background: var(--accent);
+}
+.footer {
+  padding: 12px 20px 20px;
+  text-align: right;
+  color: #64748b;
+  font-size: 12px;
+}
+.right {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+textarea:focus,
+input:focus,
+select:focus,
+button:focus {
+  outline: 2px solid var(--accent-dark);
+  outline-offset: 2px;
+}
+@media (max-width: 960px) {
+  .app {
+    grid-template-columns: 1fr;
+  }
+  .sidebar {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+  }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: true
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold a Vite + React workspace with routing, local storage state, and NEOM-branded styling
- implement portfolio, stage gates, LUP, BIM, QMS, tasks, and admin modules aligned to the provided procedures
- add documentation, favicon, and configuration for running or exporting the single-page app

## Testing
- npm install *(fails: registry access returns 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68de5ad3ebd0832f9b902e605772a158